### PR TITLE
Added support for themes through Extension Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 0.9.4
+
+Provided support for default aglio theme and layout formats through Extension Settings
+
 ### 0.9.3
 
 Adding command to save preview as HTML

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ We recommend installing [API Elements Extension](https://marketplace.visualstudi
 
 - Preview your API Blueprint file right in Visual Studio Code
 - Preview automatically when you save your `.apib` file
+- Customize theme and layout through Extension Settings
 - Save your rendered API Blueprint preview as HTML file for easy publishing
 
 ## Possible features
 
-- Theming
+- ~~Default aglio theme support~~
+- Themes provided through custom files
 - Reload on file change without the need of saving

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "icon": "img/logo_dark.png",
     "license": "MIT",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "engines": {
         "vscode": "^1.30.0"
     },
@@ -69,9 +69,9 @@
         "menus": {
             "editor/title": [
                 {
-                  "when": "editorLangId == apiblueprint",
-                  "command": "develite.previewFileLive",
-                  "group": "navigation"
+                    "when": "editorLangId == apiblueprint",
+                    "command": "develite.previewFileLive",
+                    "group": "navigation"
                 }
             ],
             "commandPalette": [
@@ -88,6 +88,34 @@
                     "when": "editorLangId == apiblueprint"
                 }
             ]
+        },
+        "configuration": {
+            "title": "API Blueprint Viewer",
+            "properties": {
+                "apiBlueprintViewer.theme.template": {
+                    "type": "string",
+                    "default": "default",
+                    "enum": [
+                        "default", 
+                        "triple"
+                    ],
+                    "enumDescriptions": [
+                        "Two-column format",
+                        "Three-column format"
+                    ]
+                },
+                "apiBlueprintViewer.theme.variables": {
+                    "type": "string",
+                    "default": "default",
+                    "enum": [
+                        "default", 
+                        "streak",
+                        "flatly",
+                        "slate",
+                        "cyborg"
+                    ]
+                }
+            }
         }
     },
     "scripts": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -84,10 +84,14 @@ function renderFile(document, onRender) {
         return;
     }
 
+    const extensionConfig = vscode.workspace.getConfiguration('apiBlueprintViewer')
+    const themeTemplate = extensionConfig.get('theme.template')
+    const themeVariables = extensionConfig.get('theme.variables')
     const content = document.getText();
     const options = {
         includePath: fileLocation,
-        themeVariables: 'default'
+        themeTemplate: themeTemplate,
+        themeVariables: themeVariables
     };
     aglio.render(content, options, function (err, html, warnings) {
         if (err) {


### PR DESCRIPTION
At the time of writing, the preview pane can now support all out of the box aglio template configurations described here: https://github.com/danielgtaylor/aglio/tree/master/examples

![image](https://user-images.githubusercontent.com/5301958/89439644-19c4d500-d710-11ea-956d-600a78d495a0.png)

Thank you for building this extension @honzababarik! Super helpful and nice to not have to pay for Apiary :-)
