### PR TITLE
[FIX] Resolve conflit with ids for name apib and apibblueprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,14 +62,15 @@
                     "api blueprint"
                 ],
                 "extensions": [
-                    ".apib"
+                    ".apib",
+                    ".apiblueprint"
                 ]
             }
         ],
         "menus": {
             "editor/title": [
                 {
-                    "when": "editorLangId == apiblueprint",
+                    "when": "editorLangId == apiblueprint || editorLangId == apib",
                     "command": "develite.previewFileLive",
                     "group": "navigation"
                 }
@@ -77,15 +78,15 @@
             "commandPalette": [
                 {
                     "command": "develite.previewFile",
-                    "when": "editorLangId == apiblueprint"
+                    "when": "editorLangId == apiblueprint || editorLangId == apib"
                 },
                 {
                     "command": "develite.previewFileLive",
-                    "when": "editorLangId == apiblueprint"
+                    "when": "editorLangId == apiblueprint || editorLangId == apib"
                 },
                 {
                     "command": "develite.saveAsHtml",
-                    "when": "editorLangId == apiblueprint"
+                    "when": "editorLangId == apiblueprint || editorLangId == apib"
                 }
             ]
         },


### PR DESCRIPTION
Hello, 

In my VSCode I not see the Command because `editorLangId` conflict with `API Blueprint Language`, this use `apib`.

Thx for this extension 🙂🙏