### PR TITLE
Also active on language id `apib`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "menus": {
             "editor/title": [
                 {
-                    "when": "editorLangId == apiblueprint",
+                    "when": "(editorLangId == apiblueprint) || (editorLangId == apib)",
                     "command": "develite.previewFileLive",
                     "group": "navigation"
                 }
@@ -77,15 +77,15 @@
             "commandPalette": [
                 {
                     "command": "develite.previewFile",
-                    "when": "editorLangId == apiblueprint"
+                    "when": "(editorLangId == apiblueprint) || (editorLangId == apib)"
                 },
                 {
                     "command": "develite.previewFileLive",
-                    "when": "editorLangId == apiblueprint"
+                    "when": "(editorLangId == apiblueprint) || (editorLangId == apib)"
                 },
                 {
                     "command": "develite.saveAsHtml",
-                    "when": "editorLangId == apiblueprint"
+                    "when": "(editorLangId == apiblueprint) || (editorLangId == apib)"
                 }
             ]
         },


### PR DESCRIPTION
Make this extension support files with language ID: `apib`.

ex. https://github.com/funbox/vscode-apib-ls/blob/f2b4de6e7b6b741f474a4d3e1a6eccc0ee51dbc5/package.json#L44
